### PR TITLE
Add missing dependency "colorama" to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,11 +5,12 @@ AsteroidOS Linux control application
   - pydbus
   - mpd
   - pyowm
+  - colorama
 
 Get the necessary modules with:
 
 ```    
-pip3 install pydbus python-mpd2 pyowm
+pip3 install pydbus python-mpd2 pyowm colorama
 ```
 
 ## Setup


### PR DESCRIPTION
After trying the script again on a different install I got `ModuleNotFoundError: No module named 'colorama'` hence I added it to the README under *Prerequisites*.